### PR TITLE
feat: enhance Facebook Ads staging models with account aggregations and timestamp tracking

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -32,5 +32,5 @@ models:
         +tags: ["marts", "facebook_ads"]
 
 vars:
-  facebook_ads_source_table: 'windsor-dbt-development.raw_data.facebook_ads_windsor'
+  facebook_ads_source_table: 'windsor-dbt-development.raw_data.facebook_ads_windsor_real'
   facebook_ads_start_date: '2024-01-01'

--- a/models/staging/facebook_ads/schema.yml
+++ b/models/staging/facebook_ads/schema.yml
@@ -1,6 +1,94 @@
 version: 2
 
 models:
+
+  - name: stg_facebook_ads__accounts
+    description: Cleaned and standardized Facebook Ads account data with unique account entities
+    columns:
+      - name: account_key
+        description: Surrogate key for the account (generated from account_id)
+        tests:
+          - not_null
+          - unique
+
+      - name: account_id
+        description: Facebook Ad Account ID - unique identifier for the advertising account
+        tests:
+          - not_null
+          - unique
+
+      - name: account_name_clean
+        description: Cleaned and standardized account name with consistent formatting
+        tests:
+          - not_null
+
+      - name: account_name_raw
+        description: Original account name as provided by the source system
+        tests:
+          - not_null
+
+      - name: account_status_clean
+        description: Standardized account status from source data
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['ACTIVE', 'PAUSED', 'ARCHIVED', 'SCHEDULED', 'UNDER_REVIEW', 'REJECTED', 'ERROR', 'DRAFT', 'COMPLETED', 'UNKNOWN']
+
+      - name: account_status_raw
+        description: Original account status as provided by the source system
+        tests:
+          - not_null
+
+      - name: account_currency
+        description: Account currency (prioritizes account_currency field, falls back to currency field)
+        tests:
+          - not_null
+
+      - name: currency_raw
+        description: Original currency field from source data
+        tests:
+          - not_null
+
+      - name: campaign_statuses
+        description: Comma-separated list of all campaign statuses associated with this account
+        tests:
+          - not_null
+
+      - name: distinct_campaign_statuses_count
+        description: Count of distinct campaign statuses associated with this account
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: has_active_campaigns
+        description: Boolean flag indicating if the account has any active campaigns
+        tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]
+
+      - name: is_test_account
+        description: Boolean flag indicating if this appears to be a test account based on naming patterns
+        tests:
+          - not_null
+          - accepted_values:
+              values: [true, false]
+
+      - name: account_name_quality_flag
+        description: Data quality assessment of the account name
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid', 'Missing Name', 'Numeric Only', 'Too Short']
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
+
+
   - name: stg_facebook_ads__insights
     description: Cleaned and standardized Facebook Ads performance data from Windsor.ai with data quality filtering
     columns:
@@ -163,6 +251,11 @@ models:
           - not_null
           - accepted_values:
               values: ['Valid', 'Missing Key Fields', 'Negative Metrics', 'Invalid CTR', 'Invalid Frequency']
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
 
     tests:
       # Primary grain uniqueness test using surrogate key

--- a/models/staging/facebook_ads/sources.yml
+++ b/models/staging/facebook_ads/sources.yml
@@ -6,7 +6,7 @@ sources:
     database: windsor-dbt-development
     schema: raw_data
     tables:
-      - name: facebook_ads_windsor
+      - name: facebook_ads_windsor_real
         description: Raw Facebook Ads performance data from Windsor.ai integration
         columns:
           - name: date

--- a/models/staging/facebook_ads/stg_facebook_ads__accounts.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__accounts.sql
@@ -1,0 +1,89 @@
+{{ config(materialized='view') }}
+
+with source_data as (
+  select * from {{ source('raw_data', 'facebook_ads_windsor_real') }}
+),
+
+unique_accounts as (
+  select distinct
+    account_id,
+    account_name,
+    account_status,
+    account_currency,
+    currency,
+    -- Aggregate campaign statuses to understand account activity
+    string_agg(distinct campaign_status, ', ' order by campaign_status) as campaign_statuses,
+    count(distinct campaign_status) as distinct_campaign_statuses_count,
+    -- Check if account has any active campaigns based on campaign_status
+    countif(upper(campaign_status) in ('ACTIVE', 'LEARNING', 'LEARNING LIMITED')) > 0 as has_active_campaigns
+  from source_data
+  where account_id is not null
+    and account_id != ''
+  group by account_id, account_name, account_status, account_currency, currency
+),
+
+cleaned_accounts as (
+  select
+    {{ dbt_utils.generate_surrogate_key(['account_id']) }} as account_key,
+    
+    cast(account_id as string) as account_id,
+    
+    case 
+      when trim(account_name) = '' or account_name is null then 'Unknown Account'
+      when regexp_contains(trim(account_name), r'^[0-9]+$') then concat('Account ', trim(account_name))
+      else trim(regexp_replace(account_name, r'\s+', ' '))
+    end as account_name_clean,
+    
+    cast(account_name as string) as account_name_raw,
+    
+    -- Account status from source data (standardized)
+    case 
+      when upper(trim(coalesce(account_status, ''))) in ('ACTIVE', 'LEARNING', 'LEARNING LIMITED') then 'ACTIVE'
+      when upper(trim(coalesce(account_status, ''))) = 'PAUSED' then 'PAUSED'
+      when upper(trim(coalesce(account_status, ''))) in ('ARCHIVED', 'DELETED') then 'ARCHIVED'
+      when upper(trim(coalesce(account_status, ''))) = 'SCHEDULED' then 'SCHEDULED'
+      when upper(trim(coalesce(account_status, ''))) in ('UNDER REVIEW', 'PENDING REVIEW', 'IN REVIEW') then 'UNDER_REVIEW'
+      when upper(trim(coalesce(account_status, ''))) in ('REJECTED', 'DISAPPROVED') then 'REJECTED'
+      when upper(trim(coalesce(account_status, ''))) in ('ERROR', 'NO DELIVERY', 'NOT DELIVERING', 'LIMITED DELIVERY') then 'ERROR'
+      when upper(trim(coalesce(account_status, ''))) = 'DRAFT' then 'DRAFT'
+      when upper(trim(coalesce(account_status, ''))) = 'COMPLETED' then 'COMPLETED'
+      else 'UNKNOWN'
+    end as account_status_clean,
+    
+    cast(coalesce(account_status, 'Unknown') as string) as account_status_raw,
+    
+    -- Currency information
+    cast(coalesce(account_currency, currency, 'USD') as string) as account_currency,
+    cast(coalesce(currency, account_currency, 'USD') as string) as currency_raw,
+    
+    -- Campaign aggregation fields
+    cast(campaign_statuses as string) as campaign_statuses,
+    cast(distinct_campaign_statuses_count as int64) as distinct_campaign_statuses_count,
+    cast(has_active_campaigns as boolean) as has_active_campaigns,
+    
+    case 
+      when lower(trim(account_name)) like '%test%' 
+        or lower(trim(account_name)) like '%demo%'
+        or lower(trim(account_name)) like '%sample%'
+        or lower(trim(account_name)) like '%trial%'
+        or regexp_contains(lower(trim(account_name)), r'\b(test|demo|sample|trial)\b')
+      then true
+      else false
+    end as is_test_account,
+    
+    case 
+      when account_name is null or trim(account_name) = '' then 'Missing Name'
+      when regexp_contains(trim(account_name), r'^[0-9]+$') then 'Numeric Only'
+      when length(trim(account_name)) < 3 then 'Too Short'
+      else 'Valid'
+    end as account_name_quality_flag,
+    
+    current_timestamp() as _dbt_loaded_at
+    
+  from unique_accounts
+)
+
+select * from cleaned_accounts
+where account_id is not null
+  and account_id != ''
+order by account_name_clean

--- a/models/staging/facebook_ads/stg_facebook_ads__insights.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__insights.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='view') }}
 
 with source_data as (
-  select * from {{ source('raw_data', 'facebook_ads_windsor') }}
+  select * from {{ source('raw_data', 'facebook_ads_windsor_real') }}
 ),
 
 cleaned_data as (
@@ -81,7 +81,9 @@ cleaned_data as (
       when clicks > impressions and impressions > 0 then 'Invalid CTR'
       when frequency < 0 then 'Invalid Frequency'
       else 'Valid'
-    end as data_quality_flag
+    end as data_quality_flag,
+    
+    current_timestamp() as _dbt_loaded_at
     
   from source_data
   where date is not null


### PR DESCRIPTION
- Complete stg_facebook_ads__accounts.sql implementation with:
  * Account-level surrogate keys and unique entity extraction
  * Account name cleaning and standardization logic
  * Comprehensive account status mapping for all Facebook statuses
  * Currency handling with smart fallback logic
  * Campaign status aggregations at account level
  * Test account detection and data quality flags
- Add timestamp tracking (_dbt_loaded_at) to both accounts and insights models
- Update source table reference to facebook_ads_windsor_real
- Add comprehensive schema documentation with data validation tests
- Include currency fields and account status standardization

## Changes
- [ ] Staging models
- [ ] Tests added
- [ ] Documentation updated

## Testing
- [ ] `dbt run` passes
- [ ] `dbt test` passes