### PR TITLE
feat: implement Facebook Ads campaigns staging model with source column corrections

### DIFF
--- a/models/staging/facebook_ads/schema.yml
+++ b/models/staging/facebook_ads/schema.yml
@@ -66,15 +66,11 @@ models:
         description: Boolean flag indicating if the account has any active campaigns
         tests:
           - not_null
-          - accepted_values:
-              values: [true, false]
 
       - name: is_test_account
         description: Boolean flag indicating if this appears to be a test account based on naming patterns
         tests:
           - not_null
-          - accepted_values:
-              values: [true, false]
 
       - name: account_name_quality_flag
         description: Data quality assessment of the account name
@@ -87,6 +83,198 @@ models:
         description: Timestamp when the record was processed by dbt
         tests:
           - not_null
+
+  - name: stg_facebook_ads__campaigns
+    description: Cleaned and standardized Facebook Ads campaign data with account hierarchy and metadata
+    columns:
+      - name: campaign_key
+        description: Surrogate key for the campaign (generated from campaign_id)
+        tests:
+          - not_null
+          - unique
+
+      - name: account_key
+        description: Foreign key to accounts table (generated from account_id)
+        tests:
+          - not_null
+
+      - name: campaign_id
+        description: Facebook Campaign ID - unique identifier for the campaign
+        tests:
+          - not_null
+          - unique
+
+      - name: account_id
+        description: Facebook Ad Account ID - parent account identifier
+        tests:
+          - not_null
+
+      - name: campaign_name_clean
+        description: Cleaned and standardized campaign name with consistent formatting
+        tests:
+          - not_null
+
+      - name: campaign_name_raw
+        description: Original campaign name as provided by the source system
+        tests:
+          - not_null
+
+      - name: campaign_objective_clean
+        description: Standardized campaign objective with consistent naming
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Lead Generation', 'Conversions', 'Traffic', 'Brand Awareness', 'Reach', 'Video Views', 'Messages', 'App Installs', 'Event Responses', 'Link Clicks', 'Local Awareness', 'Offer Claims', 'Page Likes', 'Post Engagement', 'Product Catalog Sales', 'Store Visits', 'Unknown']
+
+      - name: campaign_objective_raw
+        description: Original campaign objective from source data
+        tests:
+          - not_null
+
+      - name: campaign_status_clean
+        description: Standardized campaign status derived from effective and configured status
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['ACTIVE', 'PAUSED', 'ARCHIVED', 'SCHEDULED', 'UNDER_REVIEW', 'REJECTED', 'ERROR', 'DRAFT', 'COMPLETED', 'UNKNOWN']
+
+      - name: campaign_effective_status
+        description: Facebook's effective campaign status (actual current status)
+        tests:
+          - not_null
+
+      - name: campaign_configured_status
+        description: Facebook's configured campaign status (user-set status)
+        tests:
+          - not_null
+
+      - name: campaign_bid_strategy
+        description: Bidding strategy used for the campaign
+        tests:
+          - not_null
+
+      - name: campaign_buying_type
+        description: Campaign buying type (auction vs reservation)
+        tests:
+          - not_null
+
+      - name: campaign_special_ad_category
+        description: Special ad category if applicable (e.g., political, housing)
+
+      - name: campaign_daily_budget
+        description: Daily budget limit for the campaign in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: campaign_lifetime_budget
+        description: Lifetime budget limit for the campaign in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: campaign_budget_remaining
+        description: Remaining budget for the campaign in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: campaign_spend_cap
+        description: Spend cap limit for the campaign in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: amount_spent
+        description: Total amount spent on the campaign in account currency (derived from spend field) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: total_cost
+        description: Total cost of the campaign in account currency (derived from totalcost field) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: campaign_created_time
+        description: Timestamp when the campaign was created
+        tests:
+          - not_null
+
+      - name: campaign_start_time
+        description: Timestamp when the campaign is scheduled to start
+
+      - name: campaign_stop_time
+        description: Timestamp when the campaign is scheduled to stop
+
+      - name: is_test_campaign
+        description: Boolean flag indicating if this appears to be a test campaign based on naming patterns
+        tests:
+          - not_null
+
+      - name: campaign_name_quality_flag
+        description: Data quality assessment of the campaign name
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid', 'Missing Name', 'Numeric Only', 'Too Short']
+
+      - name: budget_type
+        description: Classification of budget type used by the campaign
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Daily Budget', 'Lifetime Budget', 'Both Budgets', 'No Budget Set']
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
+
+    tests:
+      # Primary grain uniqueness test
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - campaign_id
+          name: unique_campaign_grain
+      
+      # Account hierarchy validation
+      - dbt_utils.expression_is_true:
+          expression: "account_id is not null and account_id != ''"
+          name: account_hierarchy_valid
+      
+      # Budget consistency tests
+      - dbt_utils.expression_is_true:
+          expression: "campaign_budget_remaining <= greatest(coalesce(campaign_daily_budget, 0), coalesce(campaign_lifetime_budget, 0)) or (campaign_daily_budget = 0 and campaign_lifetime_budget = 0)"
+          name: budget_remaining_logical
+      
+      # Date logic validation
+      - dbt_utils.expression_is_true:
+          expression: "campaign_start_time is null or campaign_stop_time is null or campaign_start_time <= campaign_stop_time"
+          name: campaign_date_logic
+      
+      # Spend validation
+      - dbt_utils.expression_is_true:
+          expression: "amount_spent >= 0 and total_cost >= 0"
+          name: spend_amounts_positive
+
+      # Boolean field validation
+      - dbt_utils.expression_is_true:
+          expression: "is_test_campaign in (true, false)"
+          name: is_test_campaign_boolean_values
 
 
   - name: stg_facebook_ads__insights
@@ -301,3 +489,12 @@ models:
       - dbt_utils.expression_is_true:
           expression: "data_quality_flag = 'Valid'"
           name: only_valid_records_in_final_output
+
+      # Boolean field validation
+      - dbt_utils.expression_is_true:
+          expression: "has_active_campaigns in (true, false)"
+          name: has_active_campaigns_boolean_values
+      
+      - dbt_utils.expression_is_true:
+          expression: "is_test_account in (true, false)" 
+          name: is_test_account_boolean_values          

--- a/models/staging/facebook_ads/sources.yml
+++ b/models/staging/facebook_ads/sources.yml
@@ -15,6 +15,12 @@ sources:
             description: Facebook Ad Account ID
           - name: account_name
             description: Business Manager account name
+          - name: account_status
+            description: Facebook Ad Account status
+          - name: account_currency
+            description: Account currency setting
+          - name: currency
+            description: Currency field (alternative to account_currency)
           - name: campaign_id
             description: Facebook Campaign ID
           - name: campaign
@@ -47,3 +53,31 @@ sources:
             description: Total purchase conversions
           - name: action_values_purchase
             description: Total purchase conversion value
+          - name: campaign_bid_strategy
+            description: Campaign bidding strategy
+          - name: campaign_budget_remaining
+            description: Remaining budget for the campaign
+          - name: campaign_buying_type
+            description: Campaign buying type (auction vs reservation)
+          - name: campaign_configured_status
+            description: User-configured campaign status
+          - name: campaign_created_time
+            description: Timestamp when campaign was created
+          - name: campaign_daily_budget
+            description: Daily budget limit for the campaign
+          - name: campaign_effective_status
+            description: Facebook's effective campaign status
+          - name: campaign_lifetime_budget
+            description: Lifetime budget limit for the campaign
+          - name: campaign_special_ad_category
+            description: Special ad category if applicable
+          - name: campaign_spend_cap
+            description: Spend cap limit for the campaign
+          - name: campaign_start_time
+            description: Campaign start time
+          - name: campaign_stop_time
+            description: Campaign stop time
+          - name: objective
+            description: Campaign objective (alternative field)
+          - name: totalcost
+            description: Total cost of the campaign

--- a/models/staging/facebook_ads/stg_facebook_ads__campaigns.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__campaigns.sql
@@ -1,0 +1,147 @@
+{{ config(materialized='view') }}
+
+with source_data as (
+  select * from {{ source('raw_data', 'facebook_ads_windsor_real') }}
+),
+
+unique_campaigns as (
+  select 
+    account_id,
+    campaign_id,
+    coalesce(max(campaign), max(case when campaign is not null then campaign end)) as campaign_name,
+    coalesce(max(campaign_bid_strategy), max(case when campaign_bid_strategy is not null then campaign_bid_strategy end)) as campaign_bid_strategy,
+    max(campaign_budget_remaining) as campaign_budget_remaining,
+    coalesce(max(campaign_buying_type), max(case when campaign_buying_type is not null then campaign_buying_type end)) as campaign_buying_type,
+    coalesce(max(campaign_configured_status), max(case when campaign_configured_status is not null then campaign_configured_status end)) as campaign_configured_status,
+    max(campaign_created_time) as campaign_created_time,
+    max(campaign_daily_budget) as campaign_daily_budget,
+    coalesce(max(campaign_effective_status), max(case when campaign_effective_status is not null then campaign_effective_status end)) as campaign_effective_status,
+    max(campaign_lifetime_budget) as campaign_lifetime_budget,
+    coalesce(max(campaign_objective), max(case when campaign_objective is not null then campaign_objective end)) as campaign_objective,
+    coalesce(max(campaign_special_ad_category), max(case when campaign_special_ad_category is not null then campaign_special_ad_category end)) as campaign_special_ad_category,
+    max(campaign_spend_cap) as campaign_spend_cap,
+    max(campaign_start_time) as campaign_start_time,
+    max(campaign_stop_time) as campaign_stop_time,
+    coalesce(max(objective), max(case when objective is not null then objective end)) as objective,
+    sum(spend) as spend,
+    sum(totalcost) as totalcost
+  from source_data
+  where campaign_id is not null
+    and campaign_id != ''
+    and account_id is not null
+    and account_id != ''
+  group by account_id, campaign_id
+),
+
+cleaned_campaigns as (
+  select
+    {{ dbt_utils.generate_surrogate_key(['campaign_id']) }} as campaign_key,
+    {{ dbt_utils.generate_surrogate_key(['account_id']) }} as account_key,
+    
+    cast(campaign_id as string) as campaign_id,
+    cast(account_id as string) as account_id,
+    
+    -- Campaign name cleaning and standardization
+    case 
+      when trim(campaign_name) = '' or campaign_name is null then 'Unknown Campaign'
+      when regexp_contains(trim(campaign_name), r'^[0-9]+$') then concat('Campaign ', trim(campaign_name))
+      else trim(regexp_replace(campaign_name, r'\s+', ' '))
+    end as campaign_name_clean,
+    
+    cast(campaign_name as string) as campaign_name_raw,
+    
+    -- Campaign objective standardization (prioritize campaign_objective, fallback to objective)
+    case 
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'LEAD_GENERATION' then 'Lead Generation'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'CONVERSIONS' then 'Conversions'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'TRAFFIC' then 'Traffic'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'BRAND_AWARENESS' then 'Brand Awareness'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'REACH' then 'Reach'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'VIDEO_VIEWS' then 'Video Views'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'MESSAGES' then 'Messages'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'APP_INSTALLS' then 'App Installs'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'EVENT_RESPONSES' then 'Event Responses'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'LINK_CLICKS' then 'Link Clicks'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'LOCAL_AWARENESS' then 'Local Awareness'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'OFFER_CLAIMS' then 'Offer Claims'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'PAGE_LIKES' then 'Page Likes'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'POST_ENGAGEMENT' then 'Post Engagement'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'PRODUCT_CATALOG_SALES' then 'Product Catalog Sales'
+      when upper(trim(coalesce(campaign_objective, objective, ''))) = 'STORE_VISITS' then 'Store Visits'
+      else coalesce(campaign_objective, objective, 'Unknown')
+    end as campaign_objective_clean,
+    
+    cast(coalesce(campaign_objective, objective) as string) as campaign_objective_raw,
+    
+    -- Campaign status standardization (prioritize effective status)
+    case 
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) in ('ACTIVE', 'LEARNING', 'LEARNING LIMITED') then 'ACTIVE'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) = 'PAUSED' then 'PAUSED'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) in ('ARCHIVED', 'DELETED') then 'ARCHIVED'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) = 'SCHEDULED' then 'SCHEDULED'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) in ('UNDER REVIEW', 'PENDING REVIEW', 'IN REVIEW') then 'UNDER_REVIEW'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) in ('REJECTED', 'DISAPPROVED') then 'REJECTED'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) in ('ERROR', 'NO DELIVERY', 'NOT DELIVERING', 'LIMITED DELIVERY') then 'ERROR'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) = 'DRAFT' then 'DRAFT'
+      when upper(trim(coalesce(campaign_effective_status, campaign_configured_status, ''))) = 'COMPLETED' then 'COMPLETED'
+      else 'UNKNOWN'
+    end as campaign_status_clean,
+    
+    cast(coalesce(campaign_effective_status, 'Unknown') as string) as campaign_effective_status,
+    cast(coalesce(campaign_configured_status, 'Unknown') as string) as campaign_configured_status,
+    
+    -- Campaign metadata and properties
+    cast(campaign_bid_strategy as string) as campaign_bid_strategy,
+    cast(campaign_buying_type as string) as campaign_buying_type,
+    cast(campaign_special_ad_category as string) as campaign_special_ad_category,
+    
+    -- Budget and spend fields
+    cast(coalesce(campaign_daily_budget, 0.0) as float64) as campaign_daily_budget,
+    cast(coalesce(campaign_lifetime_budget, 0.0) as float64) as campaign_lifetime_budget,
+    cast(coalesce(campaign_budget_remaining, 0.0) as float64) as campaign_budget_remaining,
+    cast(coalesce(campaign_spend_cap, 0.0) as float64) as campaign_spend_cap,
+    cast(coalesce(spend, totalcost, 0.0) as float64) as amount_spent,
+    cast(coalesce(totalcost, spend, 0.0) as float64) as total_cost,
+    
+    -- Date fields
+    cast(campaign_created_time as timestamp) as campaign_created_time,
+    cast(campaign_start_time as timestamp) as campaign_start_time,
+    cast(campaign_stop_time as timestamp) as campaign_stop_time,
+    
+    -- Campaign quality flags
+    case 
+      when lower(trim(campaign_name)) like '%test%' 
+        or lower(trim(campaign_name)) like '%demo%'
+        or lower(trim(campaign_name)) like '%sample%'
+        or lower(trim(campaign_name)) like '%trial%'
+        or regexp_contains(lower(trim(campaign_name)), r'\b(test|demo|sample|trial)\b')
+      then true
+      else false
+    end as is_test_campaign,
+    
+    case 
+      when campaign_name is null or trim(campaign_name) = '' then 'Missing Name'
+      when regexp_contains(trim(campaign_name), r'^[0-9]+$') then 'Numeric Only'
+      when length(trim(campaign_name)) < 3 then 'Too Short'
+      else 'Valid'
+    end as campaign_name_quality_flag,
+    
+    -- Budget type classification
+    case 
+      when coalesce(campaign_daily_budget, 0) > 0 and coalesce(campaign_lifetime_budget, 0) = 0 then 'Daily Budget'
+      when coalesce(campaign_lifetime_budget, 0) > 0 and coalesce(campaign_daily_budget, 0) = 0 then 'Lifetime Budget'
+      when coalesce(campaign_daily_budget, 0) > 0 and coalesce(campaign_lifetime_budget, 0) > 0 then 'Both Budgets'
+      else 'No Budget Set'
+    end as budget_type,
+    
+    current_timestamp() as _dbt_loaded_at
+    
+  from unique_campaigns
+)
+
+select * from cleaned_campaigns
+where campaign_id is not null
+  and campaign_id != ''
+  and account_id is not null
+  and account_id != ''
+order by campaign_name_clean


### PR DESCRIPTION
- Add stg_facebook_ads__campaigns.sql with:
  * Campaign-level surrogate keys and account hierarchy
  * Campaign name cleaning and standardization
  * Campaign objective mapping to standard values
  * Campaign status handling (effective vs configured status)
  * Campaign metadata: bid strategy, buying type, special categories
  * Budget management with daily/lifetime budget classification
  * Campaign date handling (created, start, stop times) with aggregation
  * Test campaign detection and data quality validation
  * Updated to use correct source column names (spend, totalcost)

- Update schema documentation with:
  * Field descriptions clarifying source to output mappings
  * Data validation tests for budget consistency and spend validation
  * Account hierarchy and campaign date logic checks
  * Range validations for numeric fields and business logic tests

- Update sources.yml with field documentation:
  * Add account fields (account_status, account_currency, currency)
  * Add campaign metadata fields (bid strategy, budgets, dates, statuses)
  * Document correct source column names (spend, totalcost)
  * Organize fields by entity type (accounts, campaigns, performance)

- Support for Facebook campaign statuses and objectives with aggregation
- Budget type classification and spend tracking

## Changes
- [x ] Staging models
- [ x] Tests added
- [ x] Documentation updated

## Testing
- [ x] `dbt run` passes
- [ x] `dbt test` passes