### PR TITLE
feat: implement Facebook Ads ads staging model with creative content analysis

### DIFF
--- a/models/staging/facebook_ads/schema.yml
+++ b/models/staging/facebook_ads/schema.yml
@@ -277,6 +277,199 @@ models:
           name: is_test_campaign_boolean_values
 
 
+  - name: stg_facebook_ads__ads
+    description: Cleaned and standardized Facebook Ads ad-level data with creative information and hierarchy
+    columns:
+      - name: ad_key
+        description: Surrogate key for the ad (generated from ad_id)
+        tests:
+          - not_null
+          - unique
+
+      - name: adset_key
+        description: Foreign key to adsets table (generated from adset_id)
+        tests:
+          - not_null
+
+      - name: account_key
+        description: Foreign key to accounts table (generated from actor_id)
+        tests:
+          - not_null
+
+      - name: ad_id
+        description: Facebook Ad ID - unique identifier for the ad
+        tests:
+          - not_null
+          - unique
+
+      - name: adset_id
+        description: Facebook Ad Set ID - parent adset identifier
+        tests:
+          - not_null
+
+      - name: account_id
+        description: Facebook Ad Account ID - parent account identifier (derived from actor_id)
+        tests:
+          - not_null
+
+      - name: ad_name_clean
+        description: Cleaned and standardized ad name with consistent formatting
+        tests:
+          - not_null
+
+      - name: ad_name_raw
+        description: Original ad name as provided by the source system
+        tests:
+          - not_null
+
+      - name: ad_status_clean
+        description: Standardized ad status
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['ACTIVE', 'PAUSED', 'ARCHIVED', 'SCHEDULED', 'UNDER_REVIEW', 'REJECTED', 'ERROR', 'DRAFT', 'COMPLETED', 'UNKNOWN']
+
+      - name: ad_status_raw
+        description: Original ad status as provided by the source system
+        tests:
+          - not_null
+
+      - name: ad_object_type
+        description: Type of ad object
+
+      - name: ad_created_time
+        description: Timestamp when the ad was created
+
+      - name: ad_title_clean
+        description: Cleaned ad title/headline with consistent formatting
+
+      - name: ad_title_raw
+        description: Original ad title from source data
+
+      - name: ad_body_clean
+        description: Cleaned ad body text with consistent formatting
+
+      - name: ad_body_raw
+        description: Original ad body text from source data
+
+      - name: ad_link
+        description: Ad link
+
+      - name: ad_link_url
+        description: Ad destination URL
+
+      - name: ad_thumbnail_url
+        description: Ad thumbnail image URL
+
+      - name: facebook_permalink_url
+        description: Facebook permalink for the ad
+
+      - name: instagram_permalink_url
+        description: Instagram permalink for the ad
+
+      - name: website_destination_url
+        description: Website destination URL
+
+      - name: desktop_feed_standard_preview_url
+        description: Desktop feed preview URL
+
+      - name: facebook_story_mobile_preview_url
+        description: Facebook story mobile preview URL
+
+      - name: instagram_standard_preview_url
+        description: Instagram standard preview URL
+
+      - name: instagram_story_preview_url
+        description: Instagram story preview URL
+
+      - name: campaign_name_raw
+        description: Campaign name for reference
+
+      - name: adset_name_raw
+        description: Ad set name for reference
+
+      - name: url_tags
+        description: URL tags/parameters
+
+      - name: source_instagram_media_id
+        description: Source Instagram media ID
+
+      - name: instagram_actor_id
+        description: Instagram actor ID
+
+      - name: is_test_ad
+        description: Boolean flag indicating if this appears to be a test ad based on naming patterns
+        tests:
+          - not_null
+
+      - name: ad_name_quality_flag
+        description: Data quality assessment of the ad name
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid', 'Missing Name', 'Numeric Only', 'Too Short']
+
+      - name: creative_content_type
+        description: Classification of creative content availability
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Title and Body', 'Title Only', 'Body Only', 'No Title or Body']
+
+      - name: has_destination_url
+        description: Boolean flag indicating if ad has a destination URL
+        tests:
+          - not_null
+
+      - name: has_social_permalink
+        description: Boolean flag indicating if ad has social media permalinks
+        tests:
+          - not_null
+
+      - name: has_thumbnail
+        description: Boolean flag indicating if ad has a thumbnail image
+        tests:
+          - not_null
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
+
+    tests:
+      # Primary grain uniqueness test
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - ad_id
+          name: unique_ad_grain
+      
+      # Hierarchy validation
+      - dbt_utils.expression_is_true:
+          expression: "account_id is not null and account_id != ''"
+          name: ad_account_hierarchy_valid
+      
+      - dbt_utils.expression_is_true:
+          expression: "adset_id is not null and adset_id != ''"
+          name: ad_adset_hierarchy_valid
+
+      # Boolean field validation
+      - dbt_utils.expression_is_true:
+          expression: "is_test_ad in (true, false)"
+          name: is_test_ad_boolean_values
+
+      - dbt_utils.expression_is_true:
+          expression: "has_destination_url in (true, false)"
+          name: has_destination_url_boolean_values
+
+      - dbt_utils.expression_is_true:
+          expression: "has_social_permalink in (true, false)"
+          name: has_social_permalink_boolean_values
+
+      - dbt_utils.expression_is_true:
+          expression: "has_thumbnail in (true, false)"
+          name: has_thumbnail_boolean_values
+
+
   - name: stg_facebook_ads__insights
     description: Cleaned and standardized Facebook Ads performance data from Windsor.ai with data quality filtering
     columns:

--- a/models/staging/facebook_ads/sources.yml
+++ b/models/staging/facebook_ads/sources.yml
@@ -81,3 +81,50 @@ sources:
             description: Campaign objective (alternative field)
           - name: totalcost
             description: Total cost of the campaign
+      - name: facebook_ads_windsor_ads
+        description: Raw Facebook Ads data with ad-level details from Windsor.ai integration
+        columns:
+          - name: actor_id
+            description: Facebook Ad Account ID
+          - name: ad_created_time
+            description: Timestamp when ad was created
+          - name: ad_id
+            description: Facebook Ad ID
+          - name: ad_name
+            description: Ad name
+          - name: ad_object_type
+            description: Type of ad object
+          - name: adset_id
+            description: Facebook Ad Set ID
+          - name: status
+            description: Ad status
+          - name: title
+            description: Ad title/headline
+          - name: body
+            description: Ad body text
+          - name: link
+            description: Ad link
+          - name: link_url
+            description: Ad destination URL
+          - name: thumbnail_url
+            description: Ad thumbnail image URL
+          - name: facebook_permalink_url
+            description: Facebook permalink for the ad
+          - name: instagram_permalink_url
+            description: Instagram permalink for the ad
+          - name: website_destination_url
+            description: Website destination URL
+          - name: desktop_feed_standard_preview_url
+            description: Desktop feed preview URL
+          - name: facebook_story_mobile_preview_url
+            description: Facebook story mobile preview URL
+          - name: instagram_standard_preview_url
+            description: Instagram standard preview URL
+          - name: instagram_story_preview_url
+            description: Instagram story preview URL
+          - name: url_tags
+            description: URL tags/parameters
+          - name: source_instagram_media_id
+            description: Source Instagram media ID
+          - name: instagram_actor_id
+            description: Instagram actor ID

--- a/models/staging/facebook_ads/stg_facebook_ads__ads.sql
+++ b/models/staging/facebook_ads/stg_facebook_ads__ads.sql
@@ -1,0 +1,169 @@
+{{ config(materialized='view') }}
+
+with source_data as (
+  select * from {{ source('raw_data', 'facebook_ads_windsor_ads') }}
+),
+
+unique_ads as (
+  select 
+    actor_id,
+    adset_id,
+    ad_id,
+    coalesce(max(ad_name), max(case when ad_name is not null then ad_name end)) as ad_name,
+    max(ad_created_time) as ad_created_time,
+    coalesce(max(ad_object_type), max(case when ad_object_type is not null then ad_object_type end)) as ad_object_type,
+    coalesce(max(status), max(case when status is not null then status end)) as ad_status,
+    
+    -- Creative information
+    coalesce(max(title), max(case when title is not null then title end)) as ad_title,
+    coalesce(max(body), max(case when body is not null then body end)) as ad_body,
+    coalesce(max(link), max(case when link is not null then link end)) as ad_link,
+    coalesce(max(link_url), max(case when link_url is not null then link_url end)) as ad_link_url,
+    coalesce(max(thumbnail_url), max(case when thumbnail_url is not null then thumbnail_url end)) as ad_thumbnail_url,
+    coalesce(max(facebook_permalink_url), max(case when facebook_permalink_url is not null then facebook_permalink_url end)) as facebook_permalink_url,
+    coalesce(max(instagram_permalink_url), max(case when instagram_permalink_url is not null then instagram_permalink_url end)) as instagram_permalink_url,
+    coalesce(max(website_destination_url), max(case when website_destination_url is not null then website_destination_url end)) as website_destination_url,
+    
+    -- Preview URLs
+    coalesce(max(desktop_feed_standard_preview_url), max(case when desktop_feed_standard_preview_url is not null then desktop_feed_standard_preview_url end)) as desktop_feed_standard_preview_url,
+    coalesce(max(facebook_story_mobile_preview_url), max(case when facebook_story_mobile_preview_url is not null then facebook_story_mobile_preview_url end)) as facebook_story_mobile_preview_url,
+    coalesce(max(instagram_standard_preview_url), max(case when instagram_standard_preview_url is not null then instagram_standard_preview_url end)) as instagram_standard_preview_url,
+    coalesce(max(instagram_story_preview_url), max(case when instagram_story_preview_url is not null then instagram_story_preview_url end)) as instagram_story_preview_url,
+    
+    -- Additional metadata
+    coalesce(max(url_tags), max(case when url_tags is not null then url_tags end)) as url_tags,
+    coalesce(max(source_instagram_media_id), max(case when source_instagram_media_id is not null then source_instagram_media_id end)) as source_instagram_media_id,
+    max(instagram_actor_id) as instagram_actor_id
+    
+  from source_data
+  where ad_id is not null
+    and ad_id != ''
+    and actor_id is not null
+    and actor_id != ''
+  group by actor_id, adset_id, ad_id
+),
+
+cleaned_ads as (
+  select
+    {{ dbt_utils.generate_surrogate_key(['ad_id']) }} as ad_key,
+    {{ dbt_utils.generate_surrogate_key(['adset_id']) }} as adset_key,
+    {{ dbt_utils.generate_surrogate_key(['actor_id']) }} as account_key,
+    
+    cast(ad_id as string) as ad_id,
+    cast(adset_id as string) as adset_id,
+    cast(actor_id as string) as account_id,
+    
+    -- Ad name cleaning and standardization
+    case 
+      when trim(ad_name) = '' or ad_name is null then 'Unknown Ad'
+      when regexp_contains(trim(ad_name), r'^[0-9]+$') then concat('Ad ', trim(ad_name))
+      else trim(regexp_replace(ad_name, r'\s+', ' '))
+    end as ad_name_clean,
+    
+    cast(ad_name as string) as ad_name_raw,
+    
+    -- Ad status standardization
+    case 
+      when upper(trim(coalesce(ad_status, ''))) in ('ACTIVE', 'LEARNING', 'LEARNING LIMITED') then 'ACTIVE'
+      when upper(trim(coalesce(ad_status, ''))) = 'PAUSED' then 'PAUSED'
+      when upper(trim(coalesce(ad_status, ''))) in ('ARCHIVED', 'DELETED') then 'ARCHIVED'
+      when upper(trim(coalesce(ad_status, ''))) = 'SCHEDULED' then 'SCHEDULED'
+      when upper(trim(coalesce(ad_status, ''))) in ('UNDER REVIEW', 'PENDING REVIEW', 'IN REVIEW') then 'UNDER_REVIEW'
+      when upper(trim(coalesce(ad_status, ''))) in ('REJECTED', 'DISAPPROVED') then 'REJECTED'
+      when upper(trim(coalesce(ad_status, ''))) in ('ERROR', 'NO DELIVERY', 'NOT DELIVERING', 'LIMITED DELIVERY') then 'ERROR'
+      when upper(trim(coalesce(ad_status, ''))) = 'DRAFT' then 'DRAFT'
+      when upper(trim(coalesce(ad_status, ''))) = 'COMPLETED' then 'COMPLETED'
+      else 'UNKNOWN'
+    end as ad_status_clean,
+    
+    cast(coalesce(ad_status, 'Unknown') as string) as ad_status_raw,
+    
+    -- Ad metadata
+    cast(ad_object_type as string) as ad_object_type,
+    cast(ad_created_time as timestamp) as ad_created_time,
+    
+    -- Creative information
+    case 
+      when trim(ad_title) = '' or ad_title is null then null
+      else trim(regexp_replace(ad_title, r'\s+', ' '))
+    end as ad_title_clean,
+    
+    cast(ad_title as string) as ad_title_raw,
+    
+    case 
+      when trim(ad_body) = '' or ad_body is null then null
+      else trim(regexp_replace(ad_body, r'\s+', ' '))
+    end as ad_body_clean,
+    
+    cast(ad_body as string) as ad_body_raw,
+    
+    cast(ad_link as string) as ad_link,
+    cast(ad_link_url as string) as ad_link_url,
+    cast(ad_thumbnail_url as string) as ad_thumbnail_url,
+    cast(facebook_permalink_url as string) as facebook_permalink_url,
+    cast(instagram_permalink_url as string) as instagram_permalink_url,
+    cast(website_destination_url as string) as website_destination_url,
+    
+    -- Preview URLs
+    cast(desktop_feed_standard_preview_url as string) as desktop_feed_standard_preview_url,
+    cast(facebook_story_mobile_preview_url as string) as facebook_story_mobile_preview_url,
+    cast(instagram_standard_preview_url as string) as instagram_standard_preview_url,
+    cast(instagram_story_preview_url as string) as instagram_story_preview_url,
+    
+    -- Additional metadata
+    cast(url_tags as string) as url_tags,
+    cast(source_instagram_media_id as string) as source_instagram_media_id,
+    cast(instagram_actor_id as string) as instagram_actor_id,
+    
+    -- Ad quality flags
+    case 
+      when lower(trim(ad_name)) like '%test%' 
+        or lower(trim(ad_name)) like '%demo%'
+        or lower(trim(ad_name)) like '%sample%'
+        or lower(trim(ad_name)) like '%trial%'
+        or regexp_contains(lower(trim(ad_name)), r'\b(test|demo|sample|trial)\b')
+      then true
+      else false
+    end as is_test_ad,
+    
+    case 
+      when ad_name is null or trim(ad_name) = '' then 'Missing Name'
+      when regexp_contains(trim(ad_name), r'^[0-9]+$') then 'Numeric Only'
+      when length(trim(ad_name)) < 3 then 'Too Short'
+      else 'Valid'
+    end as ad_name_quality_flag,
+    
+    -- Creative content quality indicators
+    case 
+      when ad_title is not null and ad_body is not null then 'Title and Body'
+      when ad_title is not null and ad_body is null then 'Title Only'
+      when ad_title is null and ad_body is not null then 'Body Only'
+      else 'No Title or Body'
+    end as creative_content_type,
+    
+    case 
+      when ad_link_url is not null or website_destination_url is not null then true
+      else false
+    end as has_destination_url,
+    
+    case 
+      when facebook_permalink_url is not null or instagram_permalink_url is not null then true
+      else false
+    end as has_social_permalink,
+    
+    case 
+      when ad_thumbnail_url is not null then true
+      else false
+    end as has_thumbnail,
+    
+    current_timestamp() as _dbt_loaded_at
+    
+  from unique_ads
+)
+
+select * from cleaned_ads
+where ad_id is not null
+  and ad_id != ''
+  and account_id is not null
+  and account_id != ''
+order by ad_name_clean


### PR DESCRIPTION

- Add stg_facebook_ads__ads.sql with ad-level entity extraction
- Include ad metadata, creative information, and preview URLs
- Implement ad name cleaning and status standardization
- Add creative content quality indicators and thumbnail detection
- Configure new facebook_ads_windsor_ads source table
- Add schema validation and data quality tests

## Changes
- [x ] Staging models
- [ x] Tests added
- [ x] Documentation updated

## Testing
- [ x] `dbt run` passes
- [ x] `dbt test` passes