### PR TITLE
feat: implement intermediate models for enhanced metrics and currency handling

### DIFF
--- a/models/intermediate/facebook_ads/int_facebook_ads__currency_normalized.sql
+++ b/models/intermediate/facebook_ads/int_facebook_ads__currency_normalized.sql
@@ -1,0 +1,195 @@
+{{ config(materialized='ephemeral') }}
+
+with insights_base as (
+  select 
+    -- All original fields from insights staging model
+    insights_key,
+    date_day,
+    account_id,
+    account_name,
+    campaign_id,
+    campaign_name,
+    campaign_objective,
+    campaign_status,
+    ad_id,
+    ad_name,
+    impressions,
+    clicks,
+    spend,
+    reach,
+    frequency,
+    cost_per_mille,
+    cost_per_click,
+    click_through_rate,
+    conversions,
+    conversion_value,
+    cost_per_conversion,
+    return_on_ad_spend,
+    data_quality_flag,
+    _dbt_loaded_at
+  from {{ ref('stg_facebook_ads__insights') }}
+),
+
+-- Get currency information from campaigns source data
+-- Since insights table doesn't have currency, we need to get it from campaigns
+campaign_currency_lookup as (
+  select distinct
+    account_id,
+    campaign_id,
+    -- Use account_currency first, then currency field as fallback
+    coalesce(account_currency, currency, 'USD') as account_currency
+  from {{ source('raw_data', 'facebook_ads_windsor_campaigns') }}
+  where account_id is not null 
+    and campaign_id is not null
+),
+
+-- In case we don't have campaign data, create account-level currency lookup
+account_currency_lookup as (
+  select distinct
+    account_id,
+    -- Use most common currency for each account
+    mode() over (partition by account_id) as account_currency_mode
+  from (
+    select distinct
+      account_id,
+      coalesce(account_currency, currency, 'USD') as account_currency
+    from {{ source('raw_data', 'facebook_ads_windsor_campaigns') }}
+    where account_id is not null
+  )
+),
+
+insights_with_currency as (
+  select 
+    i.*,
+    
+    -- Primary currency lookup from campaign-specific data
+    coalesce(
+      ccl.account_currency,
+      acl.account_currency_mode,
+      'USD'  -- Default fallback if no currency information found
+    ) as account_currency
+    
+  from insights_base i
+  left join campaign_currency_lookup ccl
+    on i.account_id = ccl.account_id 
+    and i.campaign_id = ccl.campaign_id
+  left join account_currency_lookup acl
+    on i.account_id = acl.account_id
+),
+
+currency_validated as (
+  select
+    *,
+    
+    -- Currency validation
+    case 
+      when account_currency is null then 'Missing Currency'
+      when length(trim(account_currency)) != 3 then 'Invalid Currency Code'
+      when upper(account_currency) not in (
+        'USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CNY', 'INR', 'BRL', 'MXN',
+        'KRW', 'SGD', 'HKD', 'NOK', 'SEK', 'DKK', 'CHF', 'PLN', 'CZK', 'HUF',
+        'RON', 'BGN', 'HRK', 'RUB', 'TRY', 'ZAR', 'ILS', 'AED', 'SAR', 'QAR',
+        'KWD', 'BHD', 'OMR', 'JOD', 'LBP', 'EGP', 'MAD', 'TND', 'DZD', 'NGN',
+        'GHS', 'KES', 'UGX', 'TZS', 'ETB', 'XOF', 'XAF', 'ZMW', 'BWP', 'SZL',
+        'LSL', 'NAD', 'MWK', 'MZN', 'AOA', 'CDF', 'RWF', 'BIF', 'DJF', 'ERN',
+        'STD', 'CVE', 'GMD', 'GNF', 'LRD', 'SLL', 'SHP', 'MVR', 'SCR', 'MUR',
+        'KMF', 'MGA', 'YER', 'AFN', 'PKR', 'LKR', 'BDT', 'BTN', 'NPR', 'MMK',
+        'LAK', 'KHR', 'VND', 'THB', 'MYR', 'IDR', 'PHP', 'TWD', 'MNT', 'KZT',
+        'UZS', 'KGS', 'TJS', 'TMT', 'AZN', 'GEL', 'AMD', 'MDL', 'UAH', 'BYN',
+        'RSD', 'MKD', 'ALL', 'BAM', 'EUR'  -- Adding EUR again to handle duplicates
+      ) then 'Unsupported Currency'
+      else 'Valid Currency'
+    end as currency_validation_flag
+  from insights_with_currency
+),
+
+final_model as (
+  select
+    -- All original fields from insights
+    insights_key,
+    date_day,
+    account_id,
+    account_name,
+    campaign_id,
+    campaign_name,
+    campaign_objective,
+    campaign_status,
+    ad_id,
+    ad_name,
+    impressions,
+    clicks,
+    spend,
+    reach,
+    frequency,
+    cost_per_mille,
+    cost_per_click,
+    click_through_rate,
+    conversions,
+    conversion_value,
+    cost_per_conversion,
+    return_on_ad_spend,
+    data_quality_flag,
+    _dbt_loaded_at,
+    
+    -- Currency information
+    upper(trim(account_currency)) as account_currency,
+    currency_validation_flag,
+    
+    -- Original currency amounts (for transparency)
+    spend as spend_original_currency,
+    conversion_value as conversion_value_original_currency,
+    cost_per_click as cost_per_click_original_currency,
+    cost_per_mille as cost_per_mille_original_currency,
+    cost_per_conversion as cost_per_conversion_original_currency
+    
+    -- Future USD conversion fields (commented out for now)
+    /*
+    -- These fields will be implemented when exchange rate data is available
+    case 
+      when account_currency = 'USD' then spend
+      when exchange_rate is not null then spend * exchange_rate
+      else null
+    end as spend_usd,
+    
+    case 
+      when account_currency = 'USD' then conversion_value
+      when exchange_rate is not null then conversion_value * exchange_rate
+      else null
+    end as conversion_value_usd,
+    
+    case 
+      when account_currency = 'USD' then cost_per_click
+      when exchange_rate is not null then cost_per_click * exchange_rate
+      else null
+    end as cost_per_click_usd,
+    
+    case 
+      when account_currency = 'USD' then cost_per_mille
+      when exchange_rate is not null then cost_per_mille * exchange_rate
+      else null
+    end as cost_per_mille_usd,
+    
+    case 
+      when account_currency = 'USD' then cost_per_conversion
+      when exchange_rate is not null then cost_per_conversion * exchange_rate
+      else null
+    end as cost_per_conversion_usd,
+    
+    -- Exchange rate metadata (for future use)
+    exchange_rate,
+    exchange_rate_date,
+    exchange_rate_source
+    */
+    
+  from currency_validated
+)
+
+select * from final_model
+where currency_validation_flag = 'Valid Currency'
+
+-- Future framework for USD conversion:
+-- 1. Create or source an exchange rates table with daily rates
+-- 2. Join on account_currency and date_day
+-- 3. Uncomment the USD conversion fields above
+-- 4. Add exchange rate quality validations
+-- 5. Consider adding exchange rate source documentation

--- a/models/intermediate/facebook_ads/int_facebook_ads__daily_metrics.sql
+++ b/models/intermediate/facebook_ads/int_facebook_ads__daily_metrics.sql
@@ -1,0 +1,161 @@
+{{ config(materialized='ephemeral') }}
+
+with base_data as (
+  select 
+    -- Core identifiers
+    insights_key,
+    date_day,
+    account_id,
+    account_name,
+    campaign_id,
+    campaign_name,
+    campaign_objective,
+    campaign_status,
+    ad_id,
+    ad_name,
+    
+    -- Raw metrics
+    impressions,
+    clicks,
+    spend,
+    reach,
+    frequency,
+    conversions,
+    conversion_value,
+    
+    -- Existing calculated fields from staging
+    cost_per_click as existing_cost_per_click,
+    cost_per_mille as existing_cost_per_mille,
+    click_through_rate as existing_click_through_rate,
+    cost_per_conversion as existing_cost_per_conversion,
+    return_on_ad_spend as existing_return_on_ad_spend,
+    
+    data_quality_flag,
+    _dbt_loaded_at
+  from {{ ref('stg_facebook_ads__insights') }}
+),
+
+calculated_metrics as (
+  select
+    *,
+    
+    -- Core business metrics with division by zero handling
+    case 
+      when impressions > 0 then (clicks / cast(impressions as float64)) * 100.0
+      else 0.0
+    end as click_through_rate,
+    
+    case 
+      when clicks > 0 then spend / cast(clicks as float64)
+      else null
+    end as cost_per_click,
+    
+    case 
+      when impressions > 0 then (spend / cast(impressions as float64)) * 1000.0
+      else null
+    end as cost_per_mille,
+    
+    case 
+      when clicks > 0 then (conversions / cast(clicks as float64)) * 100.0
+      else 0.0
+    end as conversion_rate,
+    
+    case 
+      when spend > 0 then conversion_value / spend
+      else null
+    end as return_on_ad_spend,
+    
+    case 
+      when conversions > 0 then spend / cast(conversions as float64)
+      else null
+    end as cost_per_conversion
+  from base_data
+),
+
+data_quality_enhanced as (
+  select
+    *,
+    
+    -- Enhanced data quality validations
+    case 
+      when data_quality_flag != 'Valid' then data_quality_flag
+      when click_through_rate > 100.0 then 'Invalid CTR'
+      when cost_per_click < 0 then 'Negative CPC'
+      when cost_per_mille < 0 then 'Negative CPM'
+      when conversion_rate > 100.0 then 'Invalid Conversion Rate'
+      when return_on_ad_spend < 0 then 'Negative ROAS'
+      when cost_per_conversion < 0 then 'Negative Cost Per Conversion'
+      when impressions > 0 and clicks > impressions then 'Clicks Exceed Impressions'
+      when reach > 0 and impressions > 0 and frequency != (impressions / cast(reach as float64)) then 'Frequency Calculation Error'
+      when spend > 0 and cost_per_click is not null and abs(cost_per_click - (spend / nullif(clicks, 0))) > 0.01 then 'CPC Calculation Mismatch'
+      when spend > 0 and cost_per_mille is not null and abs(cost_per_mille - ((spend / nullif(impressions, 0)) * 1000)) > 0.01 then 'CPM Calculation Mismatch'
+      else 'Valid'
+    end as enhanced_data_quality_flag,
+    
+    -- Metric reasonableness flags
+    case 
+      when click_through_rate > 50.0 then 'High CTR'
+      when cost_per_click > 10.0 then 'High CPC'
+      when conversion_rate > 20.0 then 'High Conversion Rate'
+      when return_on_ad_spend > 20.0 then 'High ROAS'
+      when frequency > 10.0 then 'High Frequency'
+      else 'Normal'
+    end as metric_alert_flag,
+    
+    -- Performance tier classification
+    case 
+      when click_through_rate >= 2.0 and conversion_rate >= 2.0 and return_on_ad_spend >= 3.0 then 'High Performer'
+      when click_through_rate >= 1.0 and conversion_rate >= 1.0 and return_on_ad_spend >= 2.0 then 'Good Performer'
+      when click_through_rate >= 0.5 and conversion_rate >= 0.5 and return_on_ad_spend >= 1.0 then 'Average Performer'
+      when spend > 0 then 'Poor Performer'
+      else 'No Spend'
+    end as performance_tier
+  from calculated_metrics
+)
+
+select
+  -- Core identifiers
+  insights_key,
+  date_day,
+  account_id,
+  account_name,
+  campaign_id,
+  campaign_name,
+  campaign_objective,
+  campaign_status,
+  ad_id,
+  ad_name,
+  
+  -- Raw metrics
+  impressions,
+  clicks,
+  spend,
+  reach,
+  frequency,
+  conversions,
+  conversion_value,
+  
+  -- Calculated business metrics (our calculations)
+  round(click_through_rate, 4) as click_through_rate,
+  round(cost_per_click, 4) as cost_per_click,
+  round(cost_per_mille, 4) as cost_per_mille,
+  round(conversion_rate, 4) as conversion_rate,
+  round(return_on_ad_spend, 4) as return_on_ad_spend,
+  round(cost_per_conversion, 4) as cost_per_conversion,
+  
+  -- Existing calculated fields from staging (for comparison)
+  round(existing_cost_per_click, 4) as staging_cost_per_click,
+  round(existing_cost_per_mille, 4) as staging_cost_per_mille,
+  round(existing_click_through_rate, 4) as staging_click_through_rate,
+  round(existing_cost_per_conversion, 4) as staging_cost_per_conversion,
+  round(existing_return_on_ad_spend, 4) as staging_return_on_ad_spend,
+  
+  -- Data quality and alerting
+  enhanced_data_quality_flag,
+  metric_alert_flag,
+  performance_tier,
+  
+  -- Metadata
+  _dbt_loaded_at
+from data_quality_enhanced
+where enhanced_data_quality_flag = 'Valid'

--- a/models/intermediate/facebook_ads/schema.yml
+++ b/models/intermediate/facebook_ads/schema.yml
@@ -1,0 +1,517 @@
+version: 2
+
+models:
+  - name: int_facebook_ads__currency_normalized
+    description: Facebook Ads insights data with currency normalization and validation framework for future USD conversion
+    columns:
+      - name: insights_key
+        description: Surrogate key for the grain (date, account_id, campaign_id, ad_id)
+        tests:
+          - not_null
+          - unique
+
+      - name: date_day
+        description: Report date for the advertising metrics
+        tests:
+          - not_null
+
+      - name: account_id
+        description: Facebook Ad Account ID - unique identifier for the advertising account
+        tests:
+          - not_null
+
+      - name: account_name
+        description: Business Manager account name - human-readable account identifier
+        tests:
+          - not_null
+
+      - name: campaign_id
+        description: Facebook Campaign ID - unique identifier for the campaign
+        tests:
+          - not_null
+
+      - name: campaign_name
+        description: Campaign name - human-readable campaign identifier
+        tests:
+          - not_null
+
+      - name: campaign_objective
+        description: Standardized Facebook campaign objective
+        tests:
+          - not_null
+
+      - name: campaign_status
+        description: Current status of the campaign
+        tests:
+          - not_null
+
+      - name: ad_id
+        description: Facebook Ad ID - unique identifier for the individual ad
+        tests:
+          - not_null
+
+      - name: ad_name
+        description: Ad name - human-readable ad identifier
+        tests:
+          - not_null
+
+      - name: impressions
+        description: Number of times the ad was displayed (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: clicks
+        description: Number of clicks on the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: spend
+        description: Amount spent on the ad in original account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: reach
+        description: Number of unique users who saw the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: frequency
+        description: Average number of times each user saw the ad (impressions/reach) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: conversions
+        description: Number of purchase conversions attributed to the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: conversion_value
+        description: Total value of purchase conversions in original account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_mille
+        description: Cost per 1000 impressions in original account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_click
+        description: Average cost per click in original account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: click_through_rate
+        description: Click-through rate as percentage (clicks/impressions * 100) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              max_value: 100.0
+              inclusive: true
+
+      - name: cost_per_conversion
+        description: Average cost per conversion in original account currency - null when no conversions (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: return_on_ad_spend
+        description: Return on ad spend ratio (conversion_value/spend) - null when no spend (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: data_quality_flag
+        description: Data quality validation flag from staging model
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid']
+
+      - name: account_currency
+        description: Three-letter currency code for the advertising account (e.g., USD, EUR, GBP)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 3
+              max_value: 3
+              inclusive: true
+
+      - name: currency_validation_flag
+        description: Currency validation result flag
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid Currency']
+
+      - name: spend_original_currency
+        description: Amount spent in the original account currency - same as spend field (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: conversion_value_original_currency
+        description: Conversion value in the original account currency - same as conversion_value field (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_click_original_currency
+        description: Cost per click in the original account currency - same as cost_per_click field (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_mille_original_currency
+        description: Cost per mille in the original account currency - same as cost_per_mille field (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_conversion_original_currency
+        description: Cost per conversion in the original account currency - same as cost_per_conversion field (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
+
+    tests:
+      # Primary grain uniqueness test
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date_day
+            - account_id
+            - campaign_id
+            - ad_id
+          name: unique_currency_normalized_grain
+      
+      # Currency validation tests
+      - dbt_utils.expression_is_true:
+          expression: "account_currency is not null and length(account_currency) = 3"
+          name: valid_currency_code_format
+      
+      - dbt_utils.expression_is_true:
+          expression: "currency_validation_flag = 'Valid Currency'"
+          name: only_valid_currencies_in_output
+      
+      # Original currency field consistency tests
+      - dbt_utils.expression_is_true:
+          expression: "spend = spend_original_currency"
+          name: spend_consistency_check
+      
+      - dbt_utils.expression_is_true:
+          expression: "conversion_value = conversion_value_original_currency"
+          name: conversion_value_consistency_check
+      
+      - dbt_utils.expression_is_true:
+          expression: "cost_per_click = cost_per_click_original_currency"
+          name: cost_per_click_consistency_check
+      
+      - dbt_utils.expression_is_true:
+          expression: "cost_per_mille = cost_per_mille_original_currency"
+          name: cost_per_mille_consistency_check
+      
+      - dbt_utils.expression_is_true:
+          expression: "(cost_per_conversion is null and cost_per_conversion_original_currency is null) or (cost_per_conversion = cost_per_conversion_original_currency)"
+          name: cost_per_conversion_consistency_check
+      
+      # Business logic validation inherited from staging
+      - dbt_utils.expression_is_true:
+          expression: "clicks <= impressions or impressions = 0"
+          name: clicks_not_exceed_impressions_currency_normalized
+      
+      - dbt_utils.expression_is_true:
+          expression: "reach <= impressions or reach = 0 or impressions = 0"
+          name: reach_not_exceed_impressions_currency_normalized
+
+  - name: int_facebook_ads__daily_metrics
+    description: Enhanced Facebook Ads daily performance metrics with recalculated business metrics and data quality validations
+    columns:
+      - name: insights_key
+        description: Surrogate key for the grain (date, account_id, campaign_id, ad_id)
+        tests:
+          - not_null
+          - unique
+
+      - name: date_day
+        description: Report date for the advertising metrics
+        tests:
+          - not_null
+
+      - name: account_id
+        description: Facebook Ad Account ID - unique identifier for the advertising account
+        tests:
+          - not_null
+
+      - name: account_name
+        description: Business Manager account name - human-readable account identifier
+        tests:
+          - not_null
+
+      - name: campaign_id
+        description: Facebook Campaign ID - unique identifier for the campaign
+        tests:
+          - not_null
+
+      - name: campaign_name
+        description: Campaign name - human-readable campaign identifier
+        tests:
+          - not_null
+
+      - name: campaign_objective
+        description: Standardized Facebook campaign objective
+        tests:
+          - not_null
+
+      - name: campaign_status
+        description: Current status of the campaign
+        tests:
+          - not_null
+
+      - name: ad_id
+        description: Facebook Ad ID - unique identifier for the individual ad
+        tests:
+          - not_null
+
+      - name: ad_name
+        description: Ad name - human-readable ad identifier
+        tests:
+          - not_null
+
+      - name: impressions
+        description: Number of times the ad was displayed (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: clicks
+        description: Number of clicks on the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: spend
+        description: Amount spent on the ad in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: reach
+        description: Number of unique users who saw the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: frequency
+        description: Average number of times each user saw the ad (impressions/reach) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: conversions
+        description: Number of purchase conversions attributed to the ad (INT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: conversion_value
+        description: Total value of purchase conversions in account currency (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: click_through_rate
+        description: Click-through rate calculated as (clicks/impressions * 100) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              max_value: 100.0
+              inclusive: true
+
+      - name: cost_per_click
+        description: Average cost per click calculated as (spend/clicks) (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_mille
+        description: Cost per 1000 impressions calculated as (spend/impressions * 1000) (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: conversion_rate
+        description: Conversion rate calculated as (conversions/clicks * 100) (FLOAT64)
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              max_value: 100.0
+              inclusive: true
+
+      - name: return_on_ad_spend
+        description: Return on ad spend calculated as (conversion_value/spend) (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: cost_per_conversion
+        description: Average cost per conversion calculated as (spend/conversions) (FLOAT64)
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0.0
+              inclusive: true
+
+      - name: staging_cost_per_click
+        description: Cost per click from staging model for comparison (FLOAT64)
+
+      - name: staging_cost_per_mille
+        description: Cost per mille from staging model for comparison (FLOAT64)
+
+      - name: staging_click_through_rate
+        description: Click through rate from staging model for comparison (FLOAT64)
+
+      - name: staging_cost_per_conversion
+        description: Cost per conversion from staging model for comparison (FLOAT64)
+
+      - name: staging_return_on_ad_spend
+        description: Return on ad spend from staging model for comparison (FLOAT64)
+
+      - name: enhanced_data_quality_flag
+        description: Enhanced data quality validation flag with additional business logic checks
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Valid', 'Invalid CTR', 'Negative CPC', 'Negative CPM', 'Invalid Conversion Rate', 'Negative ROAS', 'Negative Cost Per Conversion', 'Clicks Exceed Impressions', 'Frequency Calculation Error', 'CPC Calculation Mismatch', 'CPM Calculation Mismatch', 'Missing Key Fields', 'Negative Metrics']
+
+      - name: metric_alert_flag
+        description: Flag indicating metrics that may need attention due to unusually high values
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Normal', 'High CTR', 'High CPC', 'High Conversion Rate', 'High ROAS', 'High Frequency']
+
+      - name: performance_tier
+        description: Performance tier classification based on CTR, conversion rate, and ROAS thresholds
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['High Performer', 'Good Performer', 'Average Performer', 'Poor Performer', 'No Spend']
+
+      - name: _dbt_loaded_at
+        description: Timestamp when the record was processed by dbt
+        tests:
+          - not_null
+
+    tests:
+      # Primary grain uniqueness test
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date_day
+            - account_id
+            - campaign_id
+            - ad_id
+          name: unique_daily_metrics_grain
+      
+      # Business logic validation tests
+      - dbt_utils.expression_is_true:
+          expression: "clicks <= impressions or impressions = 0"
+          name: clicks_not_exceed_impressions_intermediate
+      
+      - dbt_utils.expression_is_true:
+          expression: "reach <= impressions or reach = 0 or impressions = 0"
+          name: reach_not_exceed_impressions_intermediate
+      
+      - dbt_utils.expression_is_true:
+          expression: "spend >= 0 and clicks >= 0 and impressions >= 0"
+          name: metrics_non_negative_intermediate
+      
+      # Calculated metric consistency tests
+      - dbt_utils.expression_is_true:
+          expression: "click_through_rate = round((clicks / nullif(impressions, 0)) * 100.0, 4) or impressions = 0"
+          name: ctr_calculation_consistent
+      
+      - dbt_utils.expression_is_true:
+          expression: "cost_per_click is null or abs(cost_per_click - (spend / nullif(clicks, 0))) < 0.0001"
+          name: cpc_calculation_consistent
+      
+      - dbt_utils.expression_is_true:
+          expression: "cost_per_mille is null or abs(cost_per_mille - ((spend / nullif(impressions, 0)) * 1000)) < 0.0001"
+          name: cpm_calculation_consistent
+      
+      - dbt_utils.expression_is_true:
+          expression: "conversion_rate = round((conversions / nullif(clicks, 0)) * 100.0, 4) or clicks = 0"
+          name: conversion_rate_calculation_consistent
+      
+      - dbt_utils.expression_is_true:
+          expression: "return_on_ad_spend is null or abs(return_on_ad_spend - (conversion_value / nullif(spend, 0))) < 0.0001"
+          name: roas_calculation_consistent
+      
+      - dbt_utils.expression_is_true:
+          expression: "cost_per_conversion is null or abs(cost_per_conversion - (spend / nullif(conversions, 0))) < 0.0001"
+          name: cost_per_conversion_calculation_consistent
+      
+      # Data quality validation
+      - dbt_utils.expression_is_true:
+          expression: "enhanced_data_quality_flag = 'Valid'"
+          name: only_valid_records_in_intermediate_output


### PR DESCRIPTION
- Add int_facebook_ads__daily_metrics.sql with recalculated business metrics
  - Calculate CTR, CPC, CPM, conversion rate, ROAS, and cost per conversion
  - Include data quality validations and performance tier classification
  - Add comparison fields with staging model calculations for validation

- Add int_facebook_ads__currency_normalized.sql for currency management
  - Identify account currency from campaigns source data with fallback logic
  - Preserve original currency amounts with explicit labeling
  - Implement currency validation for 80+ supported currencies
  - Create framework for future USD conversion with commented placeholders

- Add schema.yml documentation with column descriptions and tests
- Both models use ephemeral materialization for optimal performance
- Remove obsolete int_facebook_ads__conversions.sql model

## Changes
- [ x] Staging models
- [ x] Tests added
- [ x] Documentation updated

## Testing
- [ x] `dbt run` passes
- [ x] `dbt test` passes