### PR TITLE
feat: add campaign summary model with aggregated daily metrics

### DIFF
--- a/models/marts/facebook_ads/facebook_ads__campaign_summary.sql
+++ b/models/marts/facebook_ads/facebook_ads__campaign_summary.sql
@@ -1,0 +1,248 @@
+{{
+    config(
+        materialized='table',
+        partition_by={'field': 'date_day', 'data_type': 'date'},
+        cluster_by=['account_id', 'campaign_id']
+    )
+}}
+
+/*
+    Facebook Ads Campaign Summary Model
+    
+    This model provides daily campaign level performance metrics for business analysis.
+    
+    Use Cases:
+    - Campaign performance tracking and optimization
+    - Cross campaign performance comparison
+    - Budget allocation and analysis
+    - Campaign level ROI and ROAS monitoring
+    - Performance tier distribution analysis
+    
+    Grain: One record per campaign per day
+    Filters: Only validated data with enhanced quality flags
+*/
+
+with campaign_daily_performance as (
+    select
+        -- Date and identifiers
+        date_day,
+        account_id,
+        account_name,
+        campaign_id,
+        campaign_name,
+        campaign_objective,
+        campaign_status,
+        ad_id,
+        
+        -- Core performance metrics
+        impressions,
+        clicks,
+        spend,
+        reach,
+        frequency,
+        conversions,
+        conversion_value,
+        
+        -- Calculated efficiency metrics
+        click_through_rate,
+        cost_per_click,
+        cost_per_mille,
+        conversion_rate,
+        return_on_ad_spend,
+        cost_per_conversion,
+        
+        -- Performance classification
+        performance_tier,
+        metric_alert_flag
+    
+    from {{ ref('int_facebook_ads__daily_metrics') }}
+    where enhanced_data_quality_flag = 'Valid'
+),
+
+campaign_aggregations as (
+    select
+        -- Date and campaign hierarchy
+        date_day,
+        account_id,
+        account_name,
+        campaign_id,
+        campaign_name,
+        campaign_objective,
+        campaign_status,
+        
+        -- Aggregated volume metrics
+        sum(impressions) as total_impressions,
+        sum(clicks) as total_clicks,
+        sum(spend) as total_spend,
+        sum(reach) as total_reach,
+        sum(conversions) as total_conversions,
+        sum(conversion_value) as total_conversion_value,
+        
+        -- Weighted average frequency (impressions/reach across all ads)
+        case 
+            when sum(reach) > 0 then sum(impressions) / cast(sum(reach) as float64)
+            else 0.0
+        end as avg_frequency,
+        
+        -- Performance tier distribution
+        countif(performance_tier = 'High Performer') as high_performer_ads,
+        countif(performance_tier = 'Good Performer') as good_performer_ads,
+        countif(performance_tier = 'Average Performer') as average_performer_ads,
+        countif(performance_tier = 'Poor Performer') as poor_performer_ads,
+        countif(performance_tier = 'No Spend') as no_spend_ads,
+        count(*) as total_ads,
+        
+        -- Alert flags
+        countif(metric_alert_flag != 'Normal') as ads_with_alerts,
+        
+        -- Count of distinct ads for this campaign on this day
+        count(distinct ad_id) as active_ads_count
+        
+    from campaign_daily_performance
+    group by 1, 2, 3, 4, 5, 6, 7
+),
+
+campaign_calculated_metrics as (
+    select
+        *,
+        
+        -- Campaign-level efficiency metrics
+        case 
+            when total_impressions > 0 then (total_clicks / cast(total_impressions as float64)) * 100.0
+            else 0.0
+        end as campaign_click_through_rate,
+        
+        case 
+            when total_clicks > 0 then total_spend / cast(total_clicks as float64)
+            else null
+        end as campaign_cost_per_click,
+        
+        case 
+            when total_impressions > 0 then (total_spend / cast(total_impressions as float64)) * 1000.0
+            else null
+        end as campaign_cost_per_mille,
+        
+        case 
+            when total_clicks > 0 then (total_conversions / cast(total_clicks as float64)) * 100.0
+            else 0.0
+        end as campaign_conversion_rate,
+        
+        case 
+            when total_spend > 0 then total_conversion_value / total_spend
+            else null
+        end as campaign_return_on_ad_spend,
+        
+        case 
+            when total_conversions > 0 then total_spend / cast(total_conversions as float64)
+            else null
+        end as campaign_cost_per_conversion,
+        
+        -- Performance distribution percentages
+        case 
+            when total_ads > 0 then (high_performer_ads / cast(total_ads as float64)) * 100.0
+            else 0.0
+        end as high_performer_pct,
+        
+        case 
+            when total_ads > 0 then (good_performer_ads / cast(total_ads as float64)) * 100.0
+            else 0.0
+        end as good_performer_pct,
+        
+        case 
+            when total_ads > 0 then (average_performer_ads / cast(total_ads as float64)) * 100.0
+            else 0.0
+        end as average_performer_pct,
+        
+        case 
+            when total_ads > 0 then (poor_performer_ads / cast(total_ads as float64)) * 100.0
+            else 0.0
+        end as poor_performer_pct,
+        
+        case 
+            when total_ads > 0 then (ads_with_alerts / cast(total_ads as float64)) * 100.0
+            else 0.0
+        end as alert_rate_pct
+        
+    from campaign_aggregations
+),
+
+final_campaign_metrics as (
+    select
+        *,
+        
+        -- Campaign-level performance tier based on aggregated metrics
+        case 
+            when campaign_click_through_rate >= 2.0 and campaign_conversion_rate >= 2.0 and campaign_return_on_ad_spend >= 3.0 then 'High Performer'
+            when campaign_click_through_rate >= 1.0 and campaign_conversion_rate >= 1.0 and campaign_return_on_ad_spend >= 2.0 then 'Good Performer'
+            when campaign_click_through_rate >= 0.5 and campaign_conversion_rate >= 0.5 and campaign_return_on_ad_spend >= 1.0 then 'Average Performer'
+            when total_spend > 0 then 'Poor Performer'
+            else 'No Spend'
+        end as campaign_performance_tier,
+        
+        -- Campaign efficiency score (composite metric)
+        case 
+            when campaign_click_through_rate is not null and campaign_conversion_rate is not null and campaign_return_on_ad_spend is not null
+            then round(
+                (campaign_click_through_rate * 0.3) + 
+                (campaign_conversion_rate * 0.3) + 
+                (campaign_return_on_ad_spend * 0.4), 2
+            )
+            else null
+        end as campaign_efficiency_score
+        
+    from campaign_calculated_metrics
+)
+
+select 
+    -- Date dimension
+    date_day,
+    
+    -- Campaign hierarchy
+    account_id,
+    account_name,
+    campaign_id,
+    campaign_name,
+    campaign_objective,
+    campaign_status,
+    
+    -- Volume metrics
+    total_impressions as impressions,
+    total_clicks as clicks,
+    total_spend as spend,
+    total_reach as reach,
+    round(avg_frequency, 4) as frequency,
+    total_conversions as conversions,
+    total_conversion_value as conversion_value,
+    
+    -- Campaign efficiency metrics
+    round(campaign_click_through_rate, 4) as click_through_rate,
+    round(campaign_cost_per_click, 4) as cost_per_click,
+    round(campaign_cost_per_mille, 4) as cost_per_mille,
+    round(campaign_conversion_rate, 4) as conversion_rate,
+    round(campaign_return_on_ad_spend, 4) as return_on_ad_spend,
+    round(campaign_cost_per_conversion, 4) as cost_per_conversion,
+    
+    -- Campaign performance indicators
+    campaign_performance_tier as performance_tier,
+    campaign_efficiency_score as efficiency_score,
+    
+    -- Ad composition and distribution
+    active_ads_count,
+    total_ads,
+    high_performer_ads,
+    good_performer_ads,
+    average_performer_ads,
+    poor_performer_ads,
+    no_spend_ads,
+    
+    -- Performance distribution percentages
+    round(high_performer_pct, 2) as high_performer_pct,
+    round(good_performer_pct, 2) as good_performer_pct,
+    round(average_performer_pct, 2) as average_performer_pct,
+    round(poor_performer_pct, 2) as poor_performer_pct,
+    
+    -- Alert monitoring
+    ads_with_alerts,
+    round(alert_rate_pct, 2) as alert_rate_pct
+
+from final_campaign_metrics

--- a/models/marts/schema.yml
+++ b/models/marts/schema.yml
@@ -257,3 +257,255 @@ models:
           expression: "click_through_rate <= 100"
           config:
             where: "click_through_rate is not null"
+
+  - name: facebook_ads__campaign_summary
+    description: |
+      Campaign level aggregated performance metrics for analysis and budget optimization.
+      
+      **Business Purpose:** Campaign level aggregated performance metrics for analysis,
+      budget allocation planning, and campaign ROI analysis. Enables cross campaign performance
+      comparison and benchmarking.
+      
+      **Data Grain:** One record per campaign per day with aggregated metrics across all ads
+      within each campaign.
+      
+      **Usage Examples:**
+      - Campaign performance tracking and optimization
+      - Budget allocation planning and forecasting
+      - Campaign ROI analysis and benchmarking
+      - Performance tier distribution analysis
+      - Strategic campaign portfolio management
+      
+      **Data Freshness:** Updated daily with previous day's performance data
+      
+      **Dependencies:** Sources from int_facebook_ads__daily_metrics with enhanced data quality validation
+    
+    columns:
+      - name: date_day
+        description: "Date of the advertising activity (YYYY-MM-DD format)"
+        tests:
+          - not_null
+      
+      - name: account_id
+        description: "Unique identifier for the Facebook Ads account"
+        tests:
+          - not_null
+      
+      - name: account_name
+        description: "Human-readable name of the Facebook Ads account"
+      
+      - name: campaign_id
+        description: "Unique identifier for the Facebook advertising campaign"
+        tests:
+          - not_null
+      
+      - name: campaign_name
+        description: "Name of the Facebook advertising campaign"
+      
+      - name: campaign_objective
+        description: "Campaign goal or purpose (e.g., conversions, traffic, brand awareness)"
+      
+      - name: campaign_status
+        description: "Current status of the campaign (Active, Paused, etc.)"
+      
+      - name: impressions
+        description: "Total number of times campaign ads were displayed to users (aggregated across all ads)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: clicks
+        description: "Total number of clicks received on campaign ads (aggregated across all ads)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: spend
+        description: "Total amount spent on the campaign in USD (aggregated across all ads)"
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: reach
+        description: "Total number of unique users who saw campaign ads (aggregated across all ads)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: frequency
+        description: "Average number of times each person saw campaign ads (total_impressions/total_reach)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: conversions
+        description: "Total number of desired actions completed across campaign ads (purchases, sign-ups, etc.)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: conversion_value
+        description: "Total monetary value of conversions in USD (aggregated across all ads)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: click_through_rate
+        description: "Campaign-level percentage of impressions that resulted in clicks (total_clicks/total_impressions * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: cost_per_click
+        description: "Campaign-level average cost paid for each click (total_spend/total_clicks)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: cost_per_mille
+        description: "Campaign-level cost per thousand impressions (total_spend/total_impressions * 1000)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: conversion_rate
+        description: "Campaign-level percentage of clicks that resulted in conversions (total_conversions/total_clicks * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: return_on_ad_spend
+        description: "Campaign-level revenue generated per dollar spent on advertising (total_conversion_value/total_spend)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: cost_per_conversion
+        description: "Campaign-level average cost paid for each conversion (total_spend/total_conversions)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: performance_tier
+        description: "Campaign-level performance classification based on aggregated efficiency metrics and benchmarks"
+        tests:
+          - accepted_values:
+              values: ['High Performer', 'Good Performer', 'Average Performer', 'Poor Performer', 'No Spend']
+      
+      - name: efficiency_score
+        description: "Composite metric scoring campaign efficiency based on CTR (30%), conversion rate (30%), and ROAS (40%)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: active_ads_count
+        description: "Number of distinct active ads within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: total_ads
+        description: "Total number of ads that had activity within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: high_performer_ads
+        description: "Count of ads classified as 'High Performer' within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: good_performer_ads
+        description: "Count of ads classified as 'Good Performer' within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: average_performer_ads
+        description: "Count of ads classified as 'Average Performer' within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: poor_performer_ads
+        description: "Count of ads classified as 'Poor Performer' within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: no_spend_ads
+        description: "Count of ads with no spend within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: high_performer_pct
+        description: "Percentage of ads classified as 'High Performer' within the campaign (high_performer_ads/total_ads * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: good_performer_pct
+        description: "Percentage of ads classified as 'Good Performer' within the campaign (good_performer_ads/total_ads * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: average_performer_pct
+        description: "Percentage of ads classified as 'Average Performer' within the campaign (average_performer_ads/total_ads * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: poor_performer_pct
+        description: "Percentage of ads classified as 'Poor Performer' within the campaign (poor_performer_ads/total_ads * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+      
+      - name: ads_with_alerts
+        description: "Count of ads with performance metric alerts within the campaign on this date"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+      
+      - name: alert_rate_pct
+        description: "Percentage of ads with performance alerts within the campaign (ads_with_alerts/total_ads * 100)"
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 100
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - date_day
+            - campaign_id
+      - dbt_utils.expression_is_true:
+          expression: "clicks <= impressions"
+          config:
+            where: "impressions > 0"
+      - dbt_utils.expression_is_true:
+          expression: "click_through_rate <= 100"
+          config:
+            where: "click_through_rate is not null"
+      - dbt_utils.expression_is_true:
+          expression: "conversion_rate <= 100"
+          config:
+            where: "conversion_rate is not null"
+      - dbt_utils.expression_is_true:
+          expression: "high_performer_ads + good_performer_ads + average_performer_ads + poor_performer_ads + no_spend_ads = total_ads"
+          config:
+            where: "total_ads > 0"
+      - dbt_utils.expression_is_true:
+          expression: "active_ads_count <= total_ads"
+          config:
+            where: "total_ads > 0"


### PR DESCRIPTION
- Create facebook_ads__campaign_summary.sql model aggregating ad-level data to campaigns
- Add performance tier distribution counts and percentages across campaign ads
- Include campaign-level calculated metrics: CTR, CPC, CPM, conversion rate, ROAS
- Configure BigQuery table materialization with date partitioning and clustering
- Add schema.yml documentation with column descriptions and validation tests

## Changes
- [ x] Marts models
- [ x] Tests added
- [ x] Documentation updated

## Testing
- [ x] `dbt run` passes
- [ x] `dbt test` passes